### PR TITLE
Create feature flags for optional dependencies

### DIFF
--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -9,6 +9,11 @@ readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial"]
 description = "Geospatial primitive data types"
 
+[features]
+serde_derive = ["serde"]
+spade_ext = ["spade"]
+default = ["serde_derive", "spade_ext"]
+
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
If a crate depends on geo-types this makes it easier to turn off serde and spade. Since these features are enabled by default, this is not a breaking change.

Right now there is no way to actually turn off `serde` and `spade`. If this gets merged, it would be great if a new minor version of geo-types could be published.